### PR TITLE
fix/issue-1 : Variable opacity non déclarée dans Mine.js

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1293,6 +1293,10 @@ body {
     cursor: default;
 }
 
+.mine-tile.revealed {
+    opacity: 0.6;
+}
+
 .mine-tile.found {
     animation: foundItem 0.5s ease;
     background: rgba(245, 158, 11, 0.2);

--- a/js/systems/mine.js
+++ b/js/systems/mine.js
@@ -174,8 +174,8 @@ const Mine = {
                 classes += ' dug';
                 content = this.rewards[tile.reward].emoji;
             } else if (tile.revealed) {
+                classes += ' revealed';
                 content = this.rewards[tile.reward].emoji;
-                opacity = 0.6;
             }
             
             html += `<div class="${classes}" onclick="Mine.dig(${i})">${content}</div>`;


### PR DESCRIPTION
# Fix: Variable opacity non déclarée dans Mine.js

## Description

Cette PR corrige le bug critique où la variable `opacity` était utilisée sans être déclarée dans la méthode `updateDisplay()` du fichier `js/systems/mine.js`. Cette erreur créait une variable globale implicite au lieu d'appliquer le style CSS aux tuiles révélées par le radar.

## Problème

Dans la méthode `updateDisplay()`, la ligne suivante créait une variable globale :
```javascript
opacity = 0.6;
```

Cette erreur empêchait les tuiles révélées par le radar de s'afficher correctement avec l'opacité de 0.6.

## Solution

### 1. Modification de `js/systems/mine.js`

**Avant :**
```javascript
} else if (tile.revealed) {
    content = this.rewards[tile.reward].emoji;
    opacity = 0.6;  // ❌ Variable globale implicite
}
```

**Après :**
```javascript
} else if (tile.revealed) {
    classes += ' revealed';  // ✅ Ajout de classe CSS
    content = this.rewards[tile.reward].emoji;
}
```

### 2. Ajout du style CSS dans `css/style.css`

Ajout de la classe `.mine-tile.revealed` avec l'opacité de 0.6 :
```css
.mine-tile.revealed {
    opacity: 0.6;
}
```

## Critères d'acceptation vérifiés

- [x] La variable `opacity` n'est plus déclarée comme variable globale implicite
- [x] Les tuiles révélées par le radar affichent une opacité de 0.6 correctement
- [x] Le code utilise une classe CSS appropriée (`.revealed`)
- [x] Aucune erreur JavaScript dans la console lors de l'utilisation du radar
- [x] Le mini-jeu de mine fonctionne correctement après la correction

## Fichiers modifiés

- `js/systems/mine.js` : Correction de la méthode `updateDisplay()`
- `css/style.css` : Ajout du style `.mine-tile.revealed`

## Tests

Le projet ne dispose pas de framework de test automatisé (pytest/jest). La correction a été vérifiée manuellement :
- Le code ne crée plus de variable globale
- La classe CSS `revealed` est correctement ajoutée aux tuiles
- Le style CSS applique l'opacité de 0.6

## Impact

Cette correction résout un bug critique qui affectait directement le gameplay du mini-jeu de mine, rendant les tuiles révélées par le radar visibles avec la bonne opacité.