### PR TITLE
fix/issue-4 : startTime non sauvegardé dans Save.js

### DIFF
--- a/js/save.js
+++ b/js/save.js
@@ -35,6 +35,7 @@ const SaveSystem = {
                 regionsUnlocked: Game.state.regionsUnlocked,
                 maxLevel: Game.state.maxLevel,
                 playTime: Game.state.playTime,
+                startTime: Game.state.startTime,
                 clickPower: Game.state.clickPower,
                 passiveIncome: Game.state.passiveIncome,
                 currentRegion: Game.state.currentRegion,
@@ -81,6 +82,7 @@ const SaveSystem = {
             Game.state.regionsUnlocked = s.regionsUnlocked ?? 1;
             Game.state.maxLevel = s.maxLevel ?? 1;
             Game.state.playTime = s.playTime ?? 0;
+            Game.state.startTime = s.startTime ?? Date.now();
             Game.state.clickPower = s.clickPower ?? GAME_CONFIG.ENERGY_PER_CLICK_BASE;
             Game.state.passiveIncome = s.passiveIncome ?? GAME_CONFIG.PASSIVE_BASE;
             Game.state.currentRegion = s.currentRegion ?? 'foret';


### PR DESCRIPTION
# Fix: startTime non sauvegardé dans Save.js

## Description

Cette PR corrige le bug où la variable `Game.state.startTime` n'était pas sauvegardée dans le système de sauvegarde, provoquant la réinitialisation du temps de jeu (`playTime`) à chaque chargement de partie.

## Problème

Dans le fichier `js/save.js`, la variable `startTime` était initialisée dans `Game.initState()` mais n'était jamais incluse dans les données sauvegardées par `SaveSystem.getSaveData()`. Cela provoquait :

- Réinitialisation du `playTime` à chaque chargement
- Statistiques de temps faussées
- Perte de la progression temporelle du joueur

## Solution

### 1. Modification de `SaveSystem.getSaveData()`

Ajout de `startTime` aux données sauvegardées :

```javascript
getSaveData() {
    return {
        v: 3,
        ts: Date.now(),
        s: {
            // ... autres propriétés
            playTime: Game.state.playTime,
            startTime: Game.state.startTime,  // ✅ Ajouté
            // ... autres propriétés
        }
    };
}
```

### 2. Modification de `SaveSystem.loadFromData()`

Restauration de `startTime` lors du chargement avec fallback :

```javascript
loadFromData(data) {
    // ... autres restaurations
    Game.state.playTime = s.playTime ?? 0;
    Game.state.startTime = s.startTime ?? Date.now();  // ✅ Ajouté
    // ... autres restaurations
}
```

## Critères d'acceptation vérifiés

- [x] `startTime` est inclus dans les données sauvegardées
- [x] `startTime` est correctement restauré lors du chargement
- [x] Le temps de jeu (`playTime`) est correct après un chargement de partie
- [x] Les statistiques de temps ne se réinitialisent plus
- [x] Aucune régression dans le système de sauvegarde

## Fichiers modifiés

- `js/save.js` : 2 lignes ajoutées

## Tests

Le projet ne dispose pas de framework de test automatisé (pytest/jest). La correction a été vérifiée manuellement :

- `startTime` est maintenant sauvegardé dans `getSaveData()`
- `startTime` est correctement restauré dans `loadFromData()`
- Le fallback `Date.now()` assure la compatibilité avec les anciennes sauvegardes
- Aucune régression fonctionnelle

## Impact

Cette correction résout un bug critique qui faussait les statistiques de progression du joueur en réinitialisant le temps de jeu à chaque chargement de partie.