### PR TITLE
fix/issue-5 : Énergie jamais régénérée dans Mine.js

### DIFF
--- a/js/data/constants.js
+++ b/js/data/constants.js
@@ -58,7 +58,9 @@ const GAME_CONFIG = {
     AUTO_SAVE_INTERVAL: 30000,  // Auto-sauvegarde (ms)
     ENERGY_PER_CLICK_BASE: 1,   // Énergie par clic de base
     COMBAT_CLICK_MULTIPLIER: 2, // Multiplicateur dégâts clic en combat
-    MAX_LOG_ENTRIES: 50         // Max entrées dans le log de combat
+    MAX_LOG_ENTRIES: 50,        // Max entrées dans le log de combat
+    MINE_ENERGY_REGEN_RATE: 1,  // Énergie régénérée par tick de mine
+    MINE_ENERGY_REGEN_INTERVAL: 30000  // Intervalle de régénération (ms) = 30 secondes
 };
 
 // === CONTRÉES & ROUTES (Phase 1 : 3 premières) ===

--- a/js/game.js
+++ b/js/game.js
@@ -82,6 +82,9 @@ const Game = {
         // Mise à jour de l'incubateur
         Hatchery.update(dt);
 
+        // Mise à jour de la mine (régénération d'énergie)
+        Mine.update(dt);
+
         // Calcul du CPS
         this.updateCPS();
 

--- a/js/systems/mine.js
+++ b/js/systems/mine.js
@@ -9,6 +9,7 @@ const Mine = {
     maxEnergy: 100,
     crystalsFound: 0,
     currentTool: 'pick',
+    regenTimer: 0,  // Timer pour la régénération passive d'énergie
     tools: {
         pick: { name: 'Pioche', emoji: '⛏️', cost: 1, power: 1, area: 1 },
         bomb: { name: 'Bombe', emoji: '💣', cost: 5, power: 3, area: 3 },
@@ -148,6 +149,18 @@ const Mine = {
         }
     },
 
+    // Régénération passive d'énergie de mine
+    update(dt) {
+        this.regenTimer += dt * 1000; // Convertir dt (secondes) en ms
+        if (this.regenTimer >= GAME_CONFIG.MINE_ENERGY_REGEN_INTERVAL) {
+            this.regenTimer -= GAME_CONFIG.MINE_ENERGY_REGEN_INTERVAL;
+            if (this.energy < this.maxEnergy) {
+                this.energy = Math.min(this.maxEnergy, this.energy + GAME_CONFIG.MINE_ENERGY_REGEN_RATE);
+                this.updateDisplay();
+            }
+        }
+    },
+
     rechargeEnergy(amount = 50) {
         this.energy = Math.min(this.maxEnergy, this.energy + amount);
         this.updateDisplay();
@@ -194,7 +207,8 @@ const Mine = {
         return {
             grid: this.grid,
             energy: this.energy,
-            crystalsFound: this.crystalsFound
+            crystalsFound: this.crystalsFound,
+            regenTimer: this.regenTimer
         };
     },
 
@@ -203,6 +217,7 @@ const Mine = {
             this.grid = data.grid || this.grid;
             this.energy = data.energy ?? this.maxEnergy;
             this.crystalsFound = data.crystalsFound ?? 0;
+            this.regenTimer = data.regenTimer ?? 0;
         }
     }
 };


### PR DESCRIPTION
# Fix: Énergie jamais régénérée dans Mine.js

## Description

Cette PR corrige le bug critique où l'énergie de la mine ne se régénère jamais automatiquement, bloquant complètement le mini-jeu une fois l'énergie épuisée.

## Changements effectués

### 1. Constantes de régénération (`js/data/constants.js`)
- Ajout de `MINE_ENERGY_REGEN_RATE: 1` — Énergie régénérée par tick
- Ajout de `MINE_ENERGY_REGEN_INTERVAL: 30000` — Intervalle de régénération (30 secondes)

### 2. Système de régénération (`js/systems/mine.js`)
- Ajout de la propriété `regenTimer` pour tracker le temps écoulé
- Implémentation de la méthode `update(dt)` qui gère la régénération passive
- L'énergie se régénère de +1 toutes les 30 secondes
- L'énergie ne dépasse jamais le maximum (100)
- Mise à jour de `toJSON()` et `fromJSON()` pour sauvegarder/restaurer le timer

### 3. Intégration dans la boucle de jeu (`js/game.js`)
- Appel de `Mine.update(dt)` dans la méthode `Game.update()`
- La régénération fonctionne en continu, même hors du mini-jeu

## Critères d'acceptation validés

- [x] L'énergie se régénère passivement (+1 toutes les 30 secondes)
- [x] L'énergie ne dépasse jamais le maximum
- [x] La régénération fonctionne en arrière-plan
- [x] Le joueur peut continuer à jouer au mini-jeu après avoir épuisé son énergie
- [x] Le timer de régénération persiste entre les sessions (sauvegarde)

## Impact

- **Type** : Bug fix
- **Priorité** : Haute — Ce bug bloquait complètement le mini-jeu de mine
- **Fichiers modifiés** : 3 fichiers, +22 insertions, -2 suppressions